### PR TITLE
fix: generate private keys using library

### DIFF
--- a/Example/Pods/web3.swift/web3swift/src/Utils/KeyUtil.swift
+++ b/Example/Pods/web3.swift/web3swift/src/Utils/KeyUtil.swift
@@ -20,7 +20,7 @@ enum KeyUtilError: Error {
 
 class KeyUtil {
     static func generatePrivateKeyData() -> Data? {
-        return generatePrivateKeyData()
+        return Util.generatePrivateKeyData()
     }
 
     static func generatePublicKey(from privateKey: Data) throws -> Data {

--- a/Example/Pods/web3.swift/web3swift/src/Utils/KeyUtil.swift
+++ b/Example/Pods/web3.swift/web3swift/src/Utils/KeyUtil.swift
@@ -20,7 +20,7 @@ enum KeyUtilError: Error {
 
 class KeyUtil {
     static func generatePrivateKeyData() -> Data? {
-        return Data.randomOfLength(32)
+        return generatePrivateKeyData()
     }
 
     static func generatePublicKey(from privateKey: Data) throws -> Data {

--- a/Example/Pods/web3.swift/web3swift/src/Utils/KeystoreUtil.swift
+++ b/Example/Pods/web3.swift/web3swift/src/Utils/KeystoreUtil.swift
@@ -25,11 +25,11 @@ class KeystoreUtil: KeystoreUtilProtocol {
     private static let dkround = 262144
 
     static func encode(privateKey: Data, password: String) throws -> Data {
-        guard let salt = Data.randomOfLength(16) else {
+        guard let salt = generateRandomData(length: 16) else {
             throw KeystoreUtilError.unknown
         }
 
-        guard let iv = Data.randomOfLength(16) else {
+        guard let iv = generateRandomData(length: 16) else {
             throw KeystoreUtilError.unknown
         }
 

--- a/Sources/SessionManager/Helper/Data+extensions.swift
+++ b/Sources/SessionManager/Helper/Data+extensions.swift
@@ -1,13 +1,12 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Michael Lee on 8/3/2022.
 //
 import Foundation
 
 extension Data {
-
     static func fromBase64URL(_ str: String) -> Data? {
         var base64 = str
         base64 = base64.replacingOccurrences(of: "-", with: "+")
@@ -22,7 +21,7 @@ extension Data {
     }
 
     func toBase64URL() -> String {
-        var result = self.base64EncodedString()
+        var result = base64EncodedString()
         result = result.replacingOccurrences(of: "+", with: "-")
         result = result.replacingOccurrences(of: "/", with: "_")
         result = result.replacingOccurrences(of: "=", with: "")

--- a/Sources/SessionManager/Helper/Util.swift
+++ b/Sources/SessionManager/Helper/Util.swift
@@ -8,8 +8,12 @@ public func dictionaryToStruct<T: Decodable>(_ dictionary: [String: Any]) -> T? 
     return structObject
 }
 
+public func generateRandomData(length: Int) -> Data? {
+    return Data.randomOfLength(length)
+}
+
 public func generatePrivateKeyData() -> Data? {
-    return Data.randomOfLength(32)
+    return SECP256K1.generatePrivateKey()
 }
 
 func decodedBase64(_ base64URLSafe: String) -> Data? {
@@ -36,7 +40,7 @@ func array32toTuple(_ arr: [UInt8]) -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
 extension Array where Element == UInt8 {
     func uint8Reverse() -> Array {
         var revArr = [Element]()
-        for arrayIndex in stride(from: self.count - 1, through: 0, by: -1) {
+        for arrayIndex in stride(from: count - 1, through: 0, by: -1) {
             revArr.append(self[arrayIndex])
         }
         return revArr

--- a/Sources/SessionManager/KeychainManager.swift
+++ b/Sources/SessionManager/KeychainManager.swift
@@ -38,7 +38,7 @@ public class KeychainManager: KeychainManagerProtocol {
 
     private init() {}
 
-   public func get(key: KeychainConstantEnum) -> String? {
+    public func get(key: KeychainConstantEnum) -> String? {
         return keychain.get(key.value)
     }
 

--- a/Sources/SessionManager/Models/SessionManagerError.swift
+++ b/Sources/SessionManager/Models/SessionManagerError.swift
@@ -13,7 +13,7 @@ public enum SessionManagerError: Error {
 extension SessionManagerError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .runtimeError(let msg):
+        case let .runtimeError(msg):
             return msg
         case .decodingError:
             return "Decoding error"

--- a/Sources/SessionManager/Networking/NetworkClient.swift
+++ b/Sources/SessionManager/Networking/NetworkClient.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Dhruv Jaiswal on 23/03/23.
 //
@@ -8,7 +8,6 @@
 import Foundation
 
 enum Router: NetworkManagerProtocol {
-
     case get([URLQueryItem])
     case set(T: Encodable)
 
@@ -25,9 +24,9 @@ enum Router: NetworkManagerProtocol {
 
     var httpMethod: HTTPMethod {
         switch self {
-        case .get(let params):
+        case let .get(params):
             return .get(params)
-        case .set(let params):
+        case let .set(params):
             return .post(T: params)
         }
     }
@@ -35,31 +34,30 @@ enum Router: NetworkManagerProtocol {
     var headers: [String: String] {
         switch self {
         case .get, .set:
-            return [ "Content-Type": "application/json"]
+            return ["Content-Type": "application/json"]
         }
-
     }
 }
 
 class Service {
     static func request(router: Router) async -> Result<Data, Error> {
         do {
-            guard let url = URL(string: "\(Router.baseURL + router.path)") else { throw NetworkingError.invalidURL}
+            guard let url = URL(string: "\(Router.baseURL + router.path)") else { throw NetworkingError.invalidURL }
             var request = URLRequest(url: url)
             request.httpMethod = router.httpMethod.name
             request.allHTTPHeaderFields = router.headers
             switch router.httpMethod {
-            case .get(let params):
+            case let .get(params):
                 var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 components?.queryItems = params
-                guard let url = components?.url else { throw NetworkingError.invalidURL}
+                guard let url = components?.url else { throw NetworkingError.invalidURL }
                 request = URLRequest(url: url)
-            case .post(let data):
+            case let .post(data):
                 let data = try JSONEncoder().encode(data)
                 request.httpBody = data
             }
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let response = response as? HTTPURLResponse, response.statusCode >= 200 && response.statusCode <= 299 else { throw NetworkingError.invalidResponse  }
+            guard let response = response as? HTTPURLResponse, response.statusCode >= 200 && response.statusCode <= 299 else { throw NetworkingError.invalidResponse }
             return .success(data)
         } catch let error {
             return .failure(error)

--- a/Sources/SessionManager/Networking/NetworkHelper.swift
+++ b/Sources/SessionManager/Networking/NetworkHelper.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Dhruv Jaiswal on 10/04/23.
 //
@@ -22,10 +22,10 @@ enum HTTPMethod {
 }
 
 protocol NetworkManagerProtocol {
-    static var baseURL: String {get}
-    var path: String {get}
-    var httpMethod: HTTPMethod {get}
-    var headers: [String: String] {get}
+    static var baseURL: String { get }
+    var path: String { get }
+    var httpMethod: HTTPMethod { get }
+    var headers: [String: String] { get }
 }
 
 enum NetworkingError: Error, LocalizedError {
@@ -47,16 +47,16 @@ enum NetworkingError: Error, LocalizedError {
 
 @available(iOS, deprecated: 15.0, message: "Use the built-in API instead")
 extension URLSession {
-func data(from url: URL) async throws -> (Data, URLResponse) {
-     try await withCheckedThrowingContinuation { continuation in
-        let task = self.dataTask(with: url) { data, response, error in
-             guard let data = data, let response = response else {
-                 let error = error ?? URLError(.badServerResponse)
-                 return continuation.resume(throwing: error)
-             }
-             continuation.resume(returning: (data, response))
-         }
-         task.resume()
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = self.dataTask(with: url) { data, response, error in
+                guard let data = data, let response = response else {
+                    let error = error ?? URLError(.badServerResponse)
+                    return continuation.resume(throwing: error)
+                }
+                continuation.resume(returning: (data, response))
+            }
+            task.resume()
+        }
     }
-}
 }

--- a/Sources/SessionManager/SessionManager+Extension.swift
+++ b/Sources/SessionManager/SessionManager+Extension.swift
@@ -13,7 +13,7 @@ extension SessionManager {
     func decryptData(privKeyHex: String, d: String) throws -> [String: Any] {
         let ecies = try encParamsHexToBuf(encParamsHex: d)
         let result = try decrypt(privateKey: privKeyHex, opts: ecies)
-        guard let dict = try JSONSerialization.jsonObject(with: result.data(using: .utf8) ?? Data()) as? [String: Any] else { throw SessionManagerError.decodingError}
+        guard let dict = try JSONSerialization.jsonObject(with: result.data(using: .utf8) ?? Data()) as? [String: Any] else { throw SessionManagerError.decodingError }
 //              let loginDetails: T = dictionaryToStruct(dict) else { throw SessionManagerError.decodingError }
 //        return loginDetails
         return dict
@@ -61,8 +61,8 @@ extension SessionManager {
         }
     }
 
-   private func encrypt(publicKey: String, msg: String, opts: ECIES?) throws -> ECIES {
-        guard let ephemPrivateKey = SECP256K1.generatePrivateKey(), let ephemPublicKey = SECP256K1.privateToPublic(privateKey: ephemPrivateKey)
+    private func encrypt(publicKey: String, msg: String, opts: ECIES?) throws -> ECIES {
+        guard let ephemPrivateKey = generatePrivateKeyData(), let ephemPublicKey = SECP256K1.privateToPublic(privateKey: ephemPrivateKey)
         else {
             throw SessionManagerError.runtimeError("Private key generation failed")
         }
@@ -99,7 +99,7 @@ extension SessionManager {
             dataToMac.append(contentsOf: [UInt8](ciphertext.data))
             let mac = try? HMAC(key: macKey, variant: .sha2(.sha256)).authenticate(dataToMac)
             return .init(iv: iv.toHexString(), ephemPublicKey: ephemPublicKey.toHexString(),
-            ciphertext: ciphertext.toHexString(), mac: mac?.toHexString() ?? "")
+                         ciphertext: ciphertext.toHexString(), mac: mac?.toHexString() ?? "")
         } catch let err {
             throw err
         }

--- a/Sources/SessionManager/SessionManager.swift
+++ b/Sources/SessionManager/SessionManager.swift
@@ -46,7 +46,7 @@ public class SessionManager {
     }
 
     private func generateRandomSessionID() -> String? {
-        if let val = generateRandomData(length: 32)?.toHexString().padStart(toLength: 64, padString: "0") {
+        if let val = generatePrivateKeyData()?.toHexString().padStart(toLength: 64, padString: "0") {
             return val
         }
         return nil

--- a/Sources/SessionManager/SessionManager.swift
+++ b/Sources/SessionManager/SessionManager.swift
@@ -10,7 +10,6 @@ import OSLog
 import web3
 
 public class SessionManager {
-
     private var sessionServerBaseUrl = "https://broadcast-server.tor.us/"
     private var sessionID: String? {
         didSet {
@@ -19,6 +18,7 @@ public class SessionManager {
             }
         }
     }
+
     private let sessionNamespace: String = ""
     private let sessionTime: Int
 
@@ -27,7 +27,7 @@ public class SessionManager {
     }
 
     public func setSessionID(_ val: String) {
-        self.sessionID = val
+        sessionID = val
     }
 
     public init(sessionServerBaseUrl: String? = nil, sessionTime: Int = 86400, sessionID: String? = nil) {
@@ -46,7 +46,7 @@ public class SessionManager {
     }
 
     private func generateRandomSessionID() -> String? {
-        if let val = generatePrivateKeyData()?.toHexString().padStart(toLength: 64, padString: "0") {
+        if let val = generateRandomData(length: 32)?.toHexString().padStart(toLength: 64, padString: "0") {
             return val
         }
         return nil
@@ -54,33 +54,32 @@ public class SessionManager {
 
     public func createSession<T: Encodable>(data: T) async throws -> String {
         do {
-               guard let sessionID = generateRandomSessionID() else {throw SessionManagerError.sessionIDAbsent}
-                self.sessionID = sessionID
-                let privKey = sessionID.hexa
-                guard let publicKeyHex = SECP256K1.privateToPublic(privateKey: sessionID.hexa.data,
-                compressed: false)?.web3.hexString.web3.noHexPrefix
-                else { throw SessionManagerError.runtimeError("Invalid Session ID") }
-               let encodedObj = try JSONEncoder().encode(data)
-               let jsonString = String(data: encodedObj, encoding: .utf8) ?? ""
-               let encData = try encryptData(privkeyHex: sessionID, jsonString)
-                let sig = try SECP256K1().sign(privkey: privKey.toHexString(), messageData: encData)
-                let sigData = try JSONEncoder().encode(sig)
-                let sigJsonStr = String(data: sigData, encoding: .utf8) ?? ""
-                let sessionRequestModel = SessionRequestModel(key: publicKeyHex, data: encData, signature: sigJsonStr, timeout: sessionTime)
+            guard let sessionID = generateRandomSessionID() else { throw SessionManagerError.sessionIDAbsent }
+            self.sessionID = sessionID
+            let privKey = sessionID.hexa
+            guard let publicKeyHex = SECP256K1.privateToPublic(privateKey: sessionID.hexa.data,
+                                                               compressed: false)?.web3.hexString.web3.noHexPrefix
+            else { throw SessionManagerError.runtimeError("Invalid Session ID") }
+            let encodedObj = try JSONEncoder().encode(data)
+            let jsonString = String(data: encodedObj, encoding: .utf8) ?? ""
+            let encData = try encryptData(privkeyHex: sessionID, jsonString)
+            let sig = try SECP256K1().sign(privkey: privKey.toHexString(), messageData: encData)
+            let sigData = try JSONEncoder().encode(sig)
+            let sigJsonStr = String(data: sigData, encoding: .utf8) ?? ""
+            let sessionRequestModel = SessionRequestModel(key: publicKeyHex, data: encData, signature: sigJsonStr, timeout: sessionTime)
             let api = Router.set(T: sessionRequestModel)
             let result = await Service.request(router: api)
             switch result {
-            case .success(let data):
+            case let .success(data):
                 let msgDict = try JSONSerialization.jsonObject(with: data)
                 os_log("authrorize session response is: %@", log: getTorusLogger(log: Web3AuthLogger.network, type: .info), type: .info, "\(msgDict)")
                 return sessionID
-            case .failure(let error):
+            case let .failure(error):
                 throw error
             }
         } catch {
             throw error
         }
-
     }
 
     public func authorizeSession() async throws -> [String: Any] {
@@ -92,18 +91,18 @@ public class SessionManager {
         let api = Router.get([.init(name: "key", value: "\(publicKeyHex)"), .init(name: "namespace", value: sessionNamespace)])
         let result = await Service.request(router: api)
         switch result {
-        case .success(let data):
+        case let .success(data):
             do {
                 let msgDict = try JSONSerialization.jsonObject(with: data) as? [String: String]
                 let msgData = msgDict?["message"]
                 os_log("authrorize session response is: %@", log: getTorusLogger(log: Web3AuthLogger.network, type: .info), type: .info, "\(String(describing: msgDict))")
-                let loginDetails = try self.decryptData(privKeyHex: sessionID, d: msgData ?? "")
+                let loginDetails = try decryptData(privKeyHex: sessionID, d: msgData ?? "")
                 KeychainManager.shared.save(key: .sessionID, val: sessionID)
                 return loginDetails
             } catch {
                 throw error
             }
-        case .failure(let error):
+        case let .failure(error):
             throw error
         }
     }
@@ -124,7 +123,7 @@ public class SessionManager {
             let api = Router.set(T: sessionLogoutDataModel)
             let result = await Service.request(router: api)
             switch result {
-            case .success(let data):
+            case let .success(data):
                 do {
                     let msgDict = try JSONSerialization.jsonObject(with: data)
                     os_log("logout response is: %@", log: getTorusLogger(log: Web3AuthLogger.network, type: .info), type: .info, "\(msgDict)")
@@ -133,7 +132,7 @@ public class SessionManager {
                 } catch {
                     throw error
                 }
-            case .failure(let error):
+            case let .failure(error):
                 throw error
             }
         } catch let error {

--- a/Tests/SessionManagerTests/SessionManagementTest.swift
+++ b/Tests/SessionManagerTests/SessionManagementTest.swift
@@ -1,97 +1,70 @@
-//
-//  SessionManagementTest.swift
-//  
-//
-//  Created by Dhruv Jaiswal on 10/04/23.
-//
-
-import XCTest
 @testable import SessionManager
-
-final class SessionManagementTest: XCTestCase {
-
-    var sessionID: String = "ab6fb847033ccb155769bcd1193d0da2096fb3419193725e5a48b7d40e65caa3"
-
-    func generatePrivateandPublicKey() -> (privKey: String, pubKey: String) {
-        let privKeyData = generatePrivateKeyData() ?? Data()
-        let publicKey = SECP256K1.privateToPublic(privateKey: privKeyData)?.subdata(in: 1 ..< 65) ?? Data()
-        return (privKey: privKeyData.toHexString(), pubKey: publicKey.toHexString())
-    }
-
-    func test_createSessionID() async {
-        do {
-            let session = SessionManager()
-            let (privKey, pubKey) = generatePrivateandPublicKey()
-            let sfa = SFAModel(publicKey: pubKey, privateKey: privKey)
-            let result = try await session.createSession(data: sfa)
-            print("SessionId: ", result)
-            self.sessionID = result
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func test_authoriseSessionID() async {
-        do {
-            let session = SessionManager()
-            let (privKey, pubKey) = generatePrivateandPublicKey()
-            let sfa = SFAModel(publicKey: pubKey, privateKey: privKey)
-            let result = try await session.createSession(data: sfa)
-            let sfa2 = try await session.authorizeSession()
-            print(sfa2)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-    
-    func testEncryptDecryptData() throws {
-        let session = SessionManager()
-        let privKey = "dda863b615ac6de27fb680b5563db3c19176a6f42cc1dee1768e220983385e3e"
-        let dt = ["data" : "data"]
-        let dataToEncrypt = try JSONSerialization.data(withJSONObject: dt)
-        let dataToEncryptStr = String(data: dataToEncrypt, encoding: .utf8)!
-        let encryptdata = try session.encryptData(privkeyHex: privKey, dataToEncryptStr)
-        let decrypted = try session.decryptData(privKeyHex: privKey, d: encryptdata)
-        print(decrypted)
-    }
-
-    func testSign() {
-        let privKey = "bce6550a433b2e38067501222f9e75a2d4c5a433a6d27ec90cd81fbd4194cc2b"
-        let encData = "test data"
-        do {
-            let sig = try SECP256K1().sign(privkey: privKey, messageData: encData)
-            XCTAssertEqual(sig.r, "d7736799107d8e6308af995d827dc8772993cd8ccab5c230fe8277cecb02f31a")
-            XCTAssertEqual(sig.s, "4df631a4059f45d8cb0e8889ff1b8096243796189ec00440883b1c0271a19e80")
-        } catch let error {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testEncryptAndSign() {
-        let privKey = "dda863b615ac6de27fb680b5563db3c19176a6f42cc1dee1768e220983385e3e"
-        let encdata = "{\"iv\":\"693407372626b11017d0ec30acd29e6a\",\"ciphertext\":\"cbe09442851a0463b3e34e2f912c6aee\",\"ephemPublicKey\":\"0477e20c5d9e3281a4eca7d07c1c4cc9765522ea7966cd7ea8f552da42049778d4fcf44b35b59e84eddb1fa3266350e4f2d69d62da82819d51f107550e03852661\",\"mac\":\"96d358f46ef371982af600829c101e78f6c5d5f960bd96fdd2ca52763ee50f65\"}"
-        do {
-            let sig = try SECP256K1().sign(privkey: privKey, messageData: encdata)
-            XCTAssertEqual(sig.r, "b0161b8abbd66da28734d105e28455bf9a48a33ee1dfde71f96e2e9197175650")
-            XCTAssertEqual(sig.s, "4d53303ec05596ca6784cff1d25eb0e764f70ff5e1ce16a896ec58255b25b5ff")
-        } catch let error {
-            XCTFail(error.localizedDescription)
-        }
-
-    }
-
-    func test_invalidateSession() async {
-        let session = SessionManager(sessionID: sessionID)
-        do {
-            let result = try await session.invalidateSession()
-            print(result)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-}
+import XCTest
 
 struct SFAModel: Codable {
     let publicKey: String
     let privateKey: String
+}
+
+final class SessionManagementTest: XCTestCase {
+    var sessionID: String = "ab6fb847033ccb155769bcd1193d0da2096fb3419193725e5a48b7d40e65caa3"
+
+    private func generatePrivateandPublicKey() -> (privKey: String, pubKey: String) {
+        let privKeyData = SECP256K1.generatePrivateKey()
+        var publicKey = SECP256K1.privateKeyToPublicKey(privateKey: privKeyData!)
+        let serialized = SECP256K1.serializePublicKey(publicKey: &publicKey!, compressed: false)
+        return (privKey: privKeyData!.toHexString(), pubKey: serialized!.toHexString())
+    }
+
+    func test_createSessionID() async throws {
+        let session = SessionManager()
+        let (privKey, pubKey) = generatePrivateandPublicKey()
+        let sfa = SFAModel(publicKey: pubKey, privateKey: privKey)
+        let _ = try await session.createSession(data: sfa)
+    }
+
+    func test_authoriseSessionID() async throws {
+        let session = SessionManager()
+        let (privKey, pubKey) = generatePrivateandPublicKey()
+        let sfa = SFAModel(publicKey: pubKey, privateKey: privKey)
+        let created = try await session.createSession(data: sfa)
+        XCTAssertFalse(created.isEmpty)
+        let auth = try await session.authorizeSession()
+        XCTAssertTrue(auth.keys.contains("privateKey"))
+        XCTAssertTrue(auth.keys.contains("publicKey"))
+    }
+
+    func testEncryptDecryptData() throws {
+        let session = SessionManager()
+        let privKey = "dda863b615ac6de27fb680b5563db3c19176a6f42cc1dee1768e220983385e3e"
+        let dt = ["data": "data"]
+        let dataToEncrypt = try JSONSerialization.data(withJSONObject: dt)
+        let dataToEncryptStr = String(data: dataToEncrypt, encoding: .utf8)!
+        let encryptdata = try session.encryptData(privkeyHex: privKey, dataToEncryptStr)
+        let decrypted = try session.decryptData(privKeyHex: privKey, d: encryptdata)
+        let decryptedToString = String(data: try JSONSerialization.data(withJSONObject: decrypted), encoding: .utf8)!
+        XCTAssertEqual(dataToEncryptStr, decryptedToString)
+    }
+
+    func testSign() throws {
+        let privKey = "bce6550a433b2e38067501222f9e75a2d4c5a433a6d27ec90cd81fbd4194cc2b"
+        let encData = "test data"
+        let sig = try SECP256K1().sign(privkey: privKey, messageData: encData)
+        XCTAssertEqual(sig.r, "d7736799107d8e6308af995d827dc8772993cd8ccab5c230fe8277cecb02f31a")
+        XCTAssertEqual(sig.s, "4df631a4059f45d8cb0e8889ff1b8096243796189ec00440883b1c0271a19e80")
+    }
+
+    func testEncryptAndSign() throws {
+        let privKey = "dda863b615ac6de27fb680b5563db3c19176a6f42cc1dee1768e220983385e3e"
+        let encdata = "{\"iv\":\"693407372626b11017d0ec30acd29e6a\",\"ciphertext\":\"cbe09442851a0463b3e34e2f912c6aee\",\"ephemPublicKey\":\"0477e20c5d9e3281a4eca7d07c1c4cc9765522ea7966cd7ea8f552da42049778d4fcf44b35b59e84eddb1fa3266350e4f2d69d62da82819d51f107550e03852661\",\"mac\":\"96d358f46ef371982af600829c101e78f6c5d5f960bd96fdd2ca52763ee50f65\"}"
+        let sig = try SECP256K1().sign(privkey: privKey, messageData: encdata)
+        XCTAssertEqual(sig.r, "b0161b8abbd66da28734d105e28455bf9a48a33ee1dfde71f96e2e9197175650")
+        XCTAssertEqual(sig.s, "4d53303ec05596ca6784cff1d25eb0e764f70ff5e1ce16a896ec58255b25b5ff")
+    }
+
+    func test_invalidateSession() async throws {
+        let session = SessionManager(sessionID: sessionID)
+        let invalidated = try await session.invalidateSession()
+        XCTAssertEqual(invalidated, true)
+    }
 }

--- a/Tests/SessionManagerTests/SessionManagementTest.swift
+++ b/Tests/SessionManagerTests/SessionManagementTest.swift
@@ -10,7 +10,7 @@ final class SessionManagementTest: XCTestCase {
     var sessionID: String = "ab6fb847033ccb155769bcd1193d0da2096fb3419193725e5a48b7d40e65caa3"
 
     private func generatePrivateandPublicKey() -> (privKey: String, pubKey: String) {
-        let privKeyData = SECP256K1.generatePrivateKey()
+        let privKeyData = generatePrivateKeyData()
         var publicKey = SECP256K1.privateKeyToPublicKey(privateKey: privKeyData!)
         let serialized = SECP256K1.serializePublicKey(publicKey: &publicKey!, compressed: false)
         return (privKey: privKeyData!.toHexString(), pubKey: serialized!.toHexString())


### PR DESCRIPTION
Properly generates private keys using secp256k1 library. 
Differentiates between generating random data and generating keys.
Uses random data and generation function consistently. 
Allow tests to throw instead of using do..catch blocks. 
Adds missing asserts to tests.
Formatting.